### PR TITLE
Fix docker dev setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 # Base image
-FROM node
+FROM node:16
 
 # Work Directory in container
 WORKDIR /usr/app
 
-# COPY package.json and source code files
-COPY ./ /usr/app
+# Install app dependencies
+COPY package*.json ./
+RUN npm ci
 
-# Install dependencies
-RUN npm install
+# Copy source code
+COPY . .
+
+EXPOSE 5173
 
 # Set up a default command
-CMD [ "npm","run","dev" ]
+CMD [ "npm", "run", "dev", "--", "--host" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,6 @@ services:
   kazan:
     build: .
     volumes:
-      - ./:/usr/app 
-
+      - ./:/usr/app
+    ports:
+      - "5173:5173"


### PR DESCRIPTION
Currently you can't connect to the dev server started with `docker compose up`.

Fix container network connectivity:
1. Map a host port to the container port
1. Make vite dev server in the container listen to connections on all interfaces
    - it listens only on localhost by default, but in the container all requests from the host are not local
 
Improve dockerfile:
* Explicitly set the base image tag (always do that!)
* Install dependencies separately before copying source code. This way if the code changes but dependencies don't change, we don't have to rebuild the "install dependencies" layer